### PR TITLE
Feature/adaptation

### DIFF
--- a/falcon_telegraf/base.py
+++ b/falcon_telegraf/base.py
@@ -27,7 +27,7 @@ class Middleware:
         tags = {}
         tags.update(self._tags)
         tags['method'] = req.method
-        tags['status'] = resp.status
+        tags['status'] = resp.status[:3]
         tags['uri_template'] = req.uri_template
         return tags
 

--- a/falcon_telegraf/log_hits.py
+++ b/falcon_telegraf/log_hits.py
@@ -22,7 +22,6 @@ class LogHits(Middleware):
 
     def process_response(self, req: falcon.Request, resp: falcon.Response, resource, req_succeeded: bool):
         tags = merge_and_normalize_tags(self.get_tags(req, resp), req.context, resp.context)
-        tags['success'] = str(req_succeeded)
         self._telegraf.metric(
             self.get_metric_name(req),
             values={

--- a/falcon_telegraf/timer.py
+++ b/falcon_telegraf/timer.py
@@ -38,7 +38,6 @@ class Timer(Middleware):
         try:
             delta = timer() - req.context.pop(START_TIME)
             tags = merge_and_normalize_tags(self.get_tags(req, resp), req.context, resp.context)
-            tags['success'] = str(req_succeeded)
             self._telegraf.metric(
                 self.get_metric_name(req),
                 values={

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ tests_require = read_requirements('requirements_dev.txt')
 
 setup(
     name='falcon-telegraf-middleware',
-    version='2018.10.11.1',
+    version='2018.10.12.1',
     author='Webinterpret',
     author_email='funky_chicken@webinterpret.com',
     description='Falcon to Telegraf middlewares',

--- a/tests/integration/single_middleware/test_with_single_middleware.py
+++ b/tests/integration/single_middleware/test_with_single_middleware.py
@@ -4,14 +4,14 @@ from mockito import verify, any, contains
 def test_middleware_called(webapi, telegraf_client):
     response = webapi.get('/a')
     assert response.text == 'Success'
-    verify(telegraf_client, times=1).metric('hits-/a', values={'hits': 1}, tags={'uri_template': '/a', 'method': 'GET', 'status': '200 OK'})
+    verify(telegraf_client, times=1).metric('hits-/a', values={'hits': 1}, tags={'uri_template': '/a', 'method': 'GET', 'status': '200'})
 
 
 def test_middleware_called_n_times(webapi, telegraf_client):
     assert webapi.get('/a').text == 'Success'
     assert webapi.get('/a').text == 'Success'
     assert webapi.get('/a').text == 'Success'
-    verify(telegraf_client, times=3).metric('hits-/a', values={'hits': 1}, tags={'uri_template': '/a', 'method': 'GET', 'status': '200 OK'})
+    verify(telegraf_client, times=3).metric('hits-/a', values={'hits': 1}, tags={'uri_template': '/a', 'method': 'GET', 'status': '200'})
 
 
 def test_middleware_called_mixed(webapi, telegraf_client):
@@ -25,4 +25,4 @@ def test_middleware_called_params(webapi, telegraf_client):
     assert webapi.get('/c/1?foo=1').status_code == 200
     verify(telegraf_client, times=1).metric('hits-/c/{id}',
                                             values={'hits': 1},
-                                            tags={'uri_template': '/c/{id}', 'id': '1', 'method': 'GET', 'status': '200 OK'})
+                                            tags={'uri_template': '/c/{id}', 'id': '1', 'method': 'GET', 'status': '200'})

--- a/tests/integration/single_middleware/test_with_single_middleware.py
+++ b/tests/integration/single_middleware/test_with_single_middleware.py
@@ -4,14 +4,14 @@ from mockito import verify, any, contains
 def test_middleware_called(webapi, telegraf_client):
     response = webapi.get('/a')
     assert response.text == 'Success'
-    verify(telegraf_client, times=1).metric('hits-/a', values={'hits': 1}, tags={'uri_template': '/a', 'method': 'GET', 'success': 'True', 'status': '200 OK'})
+    verify(telegraf_client, times=1).metric('hits-/a', values={'hits': 1}, tags={'uri_template': '/a', 'method': 'GET', 'status': '200 OK'})
 
 
 def test_middleware_called_n_times(webapi, telegraf_client):
     assert webapi.get('/a').text == 'Success'
     assert webapi.get('/a').text == 'Success'
     assert webapi.get('/a').text == 'Success'
-    verify(telegraf_client, times=3).metric('hits-/a', values={'hits': 1}, tags={'uri_template': '/a', 'method': 'GET', 'success': 'True', 'status': '200 OK'})
+    verify(telegraf_client, times=3).metric('hits-/a', values={'hits': 1}, tags={'uri_template': '/a', 'method': 'GET', 'status': '200 OK'})
 
 
 def test_middleware_called_mixed(webapi, telegraf_client):
@@ -25,4 +25,4 @@ def test_middleware_called_params(webapi, telegraf_client):
     assert webapi.get('/c/1?foo=1').status_code == 200
     verify(telegraf_client, times=1).metric('hits-/c/{id}',
                                             values={'hits': 1},
-                                            tags={'uri_template': '/c/{id}', 'id': '1', 'method': 'GET', 'success': 'True', 'status': '200 OK'})
+                                            tags={'uri_template': '/c/{id}', 'id': '1', 'method': 'GET', 'status': '200 OK'})

--- a/tests/integration/timer/test_timer.py
+++ b/tests/integration/timer/test_timer.py
@@ -6,7 +6,7 @@ def test_middleware_called(webapi, telegraf_client):
     when(telegraf_client).metric(
         'timer',
         values=values_captor,
-        tags={'path': '/wait/0.2', 'success': 'True'}
+        tags={'path': '/wait/0.2'}
     )
     response = webapi.get('/wait/0.2')
     assert response.text == 'Have waited 0.2 seconds'

--- a/tests/integration/two_middlewares/test_with_two_middlewares.py
+++ b/tests/integration/two_middlewares/test_with_two_middlewares.py
@@ -4,7 +4,7 @@ from mockito import verify, any_
 def test_middleware_called_no_params(webapi, telegraf_client):
     response = webapi.get('/x')
     assert response.text == 'Success'
-    verify(telegraf_client, times=1).metric('hits-/x', values={'hits': 1}, tags={'uri_template': '/x', 'method': 'GET', 'status': '200 OK'})
+    verify(telegraf_client, times=1).metric('hits-/x', values={'hits': 1}, tags={'uri_template': '/x', 'method': 'GET', 'status': '200'})
 
 
 def test_middleware_called_params(webapi, telegraf_client):

--- a/tests/integration/two_middlewares/test_with_two_middlewares.py
+++ b/tests/integration/two_middlewares/test_with_two_middlewares.py
@@ -4,7 +4,7 @@ from mockito import verify, any_
 def test_middleware_called_no_params(webapi, telegraf_client):
     response = webapi.get('/x')
     assert response.text == 'Success'
-    verify(telegraf_client, times=1).metric('hits-/x', values={'hits': 1}, tags={'uri_template': '/x', 'method': 'GET', 'success': 'True', 'status': '200 OK'})
+    verify(telegraf_client, times=1).metric('hits-/x', values={'hits': 1}, tags={'uri_template': '/x', 'method': 'GET', 'status': '200 OK'})
 
 
 def test_middleware_called_params(webapi, telegraf_client):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -16,7 +16,7 @@ def test_base_methods():
     resp = response()
 
     assert "hits-/v1/{id}/ping" == mwr.get_metric_name(req)
-    assert {'uri_template': '/v1/{id}/ping', 'default': '1', 'method': 'GET', 'status': '200 OK'} == mwr.get_tags(req, resp)
+    assert {'uri_template': '/v1/{id}/ping', 'default': '1', 'method': 'GET', 'status': '200'} == mwr.get_tags(req, resp)
 
 
 def test_metric_name_override():

--- a/tests/test_log_hits.py
+++ b/tests/test_log_hits.py
@@ -18,7 +18,6 @@ def test_log_hits():
             'path': '/v1/1/ping',
             'foo': 'bar',
             'method': 'GET',
-            'success': 'True',
         },
     )
     mwr = LogHits(


### PR DESCRIPTION
- Do not log `success` as it's kinda covered by logging `status`.
- Log `status` in a more standardised way.